### PR TITLE
Some changes needed for initial release

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "software/ext/velib"]
+	path = software/ext/velib
+	url = git@git.victronenergy.com:victron/velib.git

--- a/software/src/battery_controller_bridge.cpp
+++ b/software/src/battery_controller_bridge.cpp
@@ -51,6 +51,7 @@ BatteryControllerBridge::BatteryControllerBridge(BatteryController *BatteryContr
 		deviceInstance = getDeviceInstance(portName, "/dev/ttyO", 256);
 	produce("/Mgmt/Connection", portName);
 	produce("/DeviceInstance", deviceInstance);
+	produce("/Capabilities", "Redflow,IntegratedSoc");
 	QString serial = BatteryController->serial();
 	produce("/Serial", serial);
 


### PR DESCRIPTION
There are 2 changes we'd like you to integrate into your repository:
- /Capabilities D-Bus paths. We are planning to use this path to trigger a Redflow battery specific page on the CCGX gui.
- velib submodule: this is a reference to our velib module. Including a submodule will cause the velib repository to be downloaded automatically when cloning this repository, provided you have access to our git server, so it is safer than adding velib code to this repository. We need the submodule in order to include the Redflow service in our automated build process.
